### PR TITLE
fix for offsets

### DIFF
--- a/adafruit_hdc302x.py
+++ b/adafruit_hdc302x.py
@@ -191,10 +191,11 @@ class HDC302x:
         )
 
     @offsets.setter
-    def offsets(self, temp: float, humid: float) -> None:
+    def offsets(self, values: Tuple[float, float]) -> None:
         """
         :param values: A tuple containing the temperature and humidity offsets.
         """
+        temp, humid = values  # Unpack tuple
         rh_offset = self._calculate_offset(humid, False)
         temp_offset = self._calculate_offset(temp, True)
         combined_offsets = (rh_offset << 8) | temp_offset


### PR DESCRIPTION
handle tuple input to match the docs, minimal change.

Tested on Pi 4, Bookworm Lite with HDC302x. Small change to have library accept tuple for offset values and unpack the tuple. 

[Forum issue](https://forums.adafruit.com/viewtopic.php?p=1049308)

example code to set offsets with proposed patch:

```
import time
import board
import adafruit_hdc302x

i2c = board.I2C()
sensor = adafruit_hdc302x.HDC302x(i2c)

sensor.offsets = (1.5, -3.0)

while True:
    raw_temp = sensor.temperature
    raw_humidity = sensor.relative_humidity
    temp_offset, humidity_offset = sensor.offsets

    print(f"Raw Temperature: {raw_temp:0.1f}°C, Offset: {temp_offset:+0.1f}°C, Corrected: {raw_temp + temp_offset:0.1f}°C")
    print(f"Raw Humidity: {raw_humidity:0.1f}%, Offset: {humidity_offset:+0.1f}%, Corrected: {raw_humidity + humidity_offset:0.1f}%")
    print()

    time.sleep(2)
```

example output:

```
Raw Temperature: 20.9°C, Offset: +1.5°C, Corrected: 22.4°C
Raw Humidity: 55.7%, Offset: -2.9%, Corrected: 52.8%

Raw Temperature: 22.7°C, Offset: +1.5°C, Corrected: 24.2°C
Raw Humidity: 52.4%, Offset: -2.9%, Corrected: 49.5%

Raw Temperature: 22.7°C, Offset: +1.5°C, Corrected: 24.2°C
Raw Humidity: 52.4%, Offset: -2.9%, Corrected: 49.5%

Raw Temperature: 22.7°C, Offset: +1.5°C, Corrected: 24.2°C
Raw Humidity: 52.4%, Offset: -2.9%, Corrected: 49.5%

Raw Temperature: 22.7°C, Offset: +1.5°C, Corrected: 24.2°C
Raw Humidity: 52.4%, Offset: -2.9%, Corrected: 49.5%
```

 